### PR TITLE
demonstrate pbr-basic clobbering normal values

### DIFF
--- a/pbr-basic/main.zig
+++ b/pbr-basic/main.zig
@@ -343,6 +343,8 @@ pub fn init(app: *App, core: *mach.Core) !void {
         model.vertices = try allocator.alloc(Vertex, vertex_count);
         model.indices = try allocator.alloc(u32, index_count);
 
+        var vertices_updated = std.AutoHashMap(usize, void).init(allocator);
+
         const scale: f32 = 0.45;
         const vertices = m3d_model.handle.vertex[0..vertex_count];
         var i: usize = 0;
@@ -379,6 +381,18 @@ pub fn init(app: *App, core: *mach.Core) !void {
             vertex2.normal[0] = vertices[normal2].x;
             vertex2.normal[1] = vertices[normal2].y;
             vertex2.normal[2] = vertices[normal2].z;
+
+            var k: usize = 0;
+            while (k < 3) : (k += 1) {
+                var v = try vertices_updated.getOrPut(face.vertex[k]);
+                if (v.found_existing) {
+                    // We're clobbering an entry!
+                    std.debug.print("CLOBBERING: {}\n", .{face.vertex[k]});
+                }
+                v.value_ptr.* = {};
+
+                std.debug.print("set vertices[{}] to normal={}\n", .{face.vertex[k], face.normal[k]});
+            }
         }
         i = 0;
         while (i < vertex_count) : (i += 1) {


### PR DESCRIPTION
When ran, we can see instances of the loop updating vertices with the same index to point to different normals:

```
set vertices[1007] to normal=5578
set vertices[435] to normal=118
set vertices[986] to normal=7356
set vertices[1005] to normal=3435
set vertices[474] to normal=38
CLOBBERING: 1007
set vertices[1007] to normal=5578
set vertices[1013] to normal=7029
set vertices[472] to normal=96
```

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>



- [ ] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.