### PR TITLE
pbr-basic: add imgui overlay

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -25,7 +25,12 @@ pub fn build(b: *std.build.Builder) !void {
         .{ .name = "triangle" },
         .{ .name = "triangle-msaa" },
         .{ .name = "boids" },
-        .{ .name = "pbr-basic", .deps = &.{ Packages.zmath, Packages.model3d, Packages.assets }, .use_model3d = true },
+        .{
+            .name = "pbr-basic",
+            .deps = &.{ Packages.zmath, Packages.model3d, Packages.mach_imgui, Packages.assets },
+            .use_model3d = true,
+            .use_imgui = true,
+        },
         .{ .name = "imgui", .deps = &.{ Packages.mach_imgui, Packages.assets }, .use_imgui = true },
         .{ .name = "rotating-cube", .deps = &.{Packages.zmath} },
         .{ .name = "pixel-post-process", .deps = &.{Packages.zmath} },

--- a/pbr-basic/imgui.wgsl
+++ b/pbr-basic/imgui.wgsl
@@ -1,0 +1,14 @@
+@fragment fn frag_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+}
+
+@vertex fn vert_main(
+    @builtin(vertex_index) VertexIndex : u32
+) -> @builtin(position) vec4<f32> {
+    var pos = array<vec2<f32>, 3>(
+        vec2<f32>( 0.0,  0.5),
+        vec2<f32>(-0.5, -0.5),
+        vec2<f32>( 0.5, -0.5)
+    );
+    return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+}


### PR DESCRIPTION
- Adds imgui overlay
- Fixes clobbering of normals when loading model
- Lighting updates at a more appropriate rate
- Vertex & Index buffers are deallocated once a model is loaded. Only WGPU buffers need to be retained.

Blocker: Seems like depth stencil information isn't being properly initialized in Dear Imgui backend and it's leading to WGPU validation errors

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.