### PR TITLE
remove all unused field(s) - upstream issue resolved

### DIFF
--- a/core/map-async/main.zig
+++ b/core/map-async/main.zig
@@ -4,9 +4,6 @@ const gpu = @import("gpu");
 
 pub const App = @This();
 
-// TODO(self-hosted): https://github.com/ziglang/zig/issues/12275
-_unused: i32,
-
 const workgroup_size = 64;
 const buffer_size = 1000;
 


### PR DESCRIPTION
Thanks to https://github.com/ziglang/zig/issues/12275 being resolved, this workaround's not needed.

This depends on https://github.com/hexops/mach/pull/647 being merged.

I'm fairly confident I found all the instances of these unused fields. If there's one I missed, lmk and I'll update.


- [ x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.