### PR TITLE
README: make example use new `mode` option (App.setBuildMode() was removed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ pub fn build(b: *std.build.Builder) !void {
         .src = "src/main.zig",
         .target = target,
         .deps = &[_]std.build.Pkg{},
+        .mode = mode,
     });
-    app.setBuildMode(mode);
     try app.link(.{});
     app.install();
 


### PR DESCRIPTION
This ensures the example respects https://github.com/hexops/mach/commit/c4842ea5c5fbbfe5ac982bb888354123c2e3e443

Currently, following the example won't build due to the change. This PR fixes that.

- [ x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.