### PR TITLE
all: remove *Core allocation

### DIFF
--- a/core/advanced-gen-texture-light/main.zig
+++ b/core/advanced-gen-texture-light/main.zig
@@ -37,7 +37,7 @@ const Dir = struct {
 };
 
 pub fn init(app: *App) !void {
-    app.core = try mach.Core.init(gpa.allocator(), .{});
+    try app.core.init(gpa.allocator(), .{});
     app.timer = try mach.Timer.start();
 
     const eye = vec3(5.0, 7.0, 5.0);

--- a/core/deferred-rendering/main.zig
+++ b/core/deferred-rendering/main.zig
@@ -145,7 +145,7 @@ is_paused: bool,
 //
 
 pub fn init(app: *App) !void {
-    app.core = try mach.Core.init(gpa.allocator(), .{});
+    try app.core.init(gpa.allocator(), .{});
 
     app.timer = try mach.Timer.start();
 

--- a/core/imgui/main.zig
+++ b/core/imgui/main.zig
@@ -41,7 +41,7 @@ fn createColorTargetState(format: gpu.Texture.Format) gpu.ColorTargetState {
 }
 
 pub fn init(app: *App) !void {
-    app.core = try mach.Core.init(gpa.allocator(), .{
+    try app.core.init(gpa.allocator(), .{
         .title = "Imgui in mach",
         .size = .{
             .width = 1000,

--- a/core/instanced-cube/main.zig
+++ b/core/instanced-cube/main.zig
@@ -23,7 +23,7 @@ bind_group: *gpu.BindGroup,
 pub const App = @This();
 
 pub fn init(app: *App) !void {
-    app.core = try mach.Core.init(gpa.allocator(), .{});
+    try app.core.init(gpa.allocator(), .{});
     app.timer = try mach.Timer.start();
 
     const shader_module = app.core.device().createShaderModuleWGSL("shader.wgsl", @embedFile("shader.wgsl"));

--- a/core/map-async/main.zig
+++ b/core/map-async/main.zig
@@ -11,7 +11,8 @@ pub fn init(_: *App) !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
 
-    var core = try mach.Core.init(gpa.allocator(), .{});
+    var core: mach.Core = undefined;
+    try core.init(gpa.allocator(), .{});
     defer core.deinit();
 
     const output = core.device().createBuffer(&.{

--- a/core/pbr-basic/main.zig
+++ b/core/pbr-basic/main.zig
@@ -320,7 +320,7 @@ is_rotating: bool,
 //
 
 pub fn init(app: *App) !void {
-    app.core = try mach.Core.init(gpa.allocator(), .{});
+    try app.core.init(gpa.allocator(), .{});
     app.timer = try mach.Timer.start();
 
     app.queue = app.core.device().getQueue();

--- a/core/pixel-post-process/main.zig
+++ b/core/pixel-post-process/main.zig
@@ -43,7 +43,7 @@ depth_texture_view: *gpu.TextureView,
 normal_texture_view: *gpu.TextureView,
 
 pub fn init(app: *App) !void {
-    app.core = try mach.Core.init(gpa.allocator(), .{});
+    try app.core.init(gpa.allocator(), .{});
     app.timer = try mach.Timer.start();
 
     try app.createRenderTextures();

--- a/core/triangle-msaa/main.zig
+++ b/core/triangle-msaa/main.zig
@@ -17,7 +17,7 @@ texture_view: *gpu.TextureView,
 const sample_count = 4;
 
 pub fn init(app: *App) !void {
-    app.core = try mach.Core.init(gpa.allocator(), .{});
+    try app.core.init(gpa.allocator(), .{});
     app.timer = try mach.Timer.start();
     app.window_title_timer = try mach.Timer.start();
 

--- a/core/triangle/main.zig
+++ b/core/triangle/main.zig
@@ -11,7 +11,7 @@ pipeline: *gpu.RenderPipeline,
 queue: *gpu.Queue,
 
 pub fn init(app: *App) !void {
-    app.core = try mach.Core.init(gpa.allocator(), .{});
+    try app.core.init(gpa.allocator(), .{});
 
     const shader_module = app.core.device().createShaderModuleWGSL("shader.wgsl", @embedFile("shader.wgsl"));
 

--- a/core/two-cubes/main.zig
+++ b/core/two-cubes/main.zig
@@ -26,7 +26,7 @@ bind_group2: *gpu.BindGroup,
 pub const App = @This();
 
 pub fn init(app: *App) !void {
-    app.core = try mach.Core.init(gpa.allocator(), .{});
+    try app.core.init(gpa.allocator(), .{});
     app.timer = try mach.Timer.start();
 
     const shader_module = app.core.device().createShaderModuleWGSL("shader.wgsl", @embedFile("shader.wgsl"));

--- a/engine/gkurve/main.zig
+++ b/engine/gkurve/main.zig
@@ -37,7 +37,7 @@ texture_atlas_data: AtlasRGB8,
 
 pub fn init(app: *App) !void {
     app.allocator = gpa.allocator();
-    app.core = try mach.Core.init(app.allocator, .{});
+    try app.core.init(app.allocator, .{});
 
     const queue = app.core.device().getQueue();
 

--- a/engine/sysaudio/main.zig
+++ b/engine/sysaudio/main.zig
@@ -31,7 +31,7 @@ const Tone = struct {
 };
 
 pub fn init(app: *App) !void {
-    app.core = try mach.Core.init(gpa.allocator(), .{});
+    try app.core.init(gpa.allocator(), .{});
 
     app.audio_ctx = try sysaudio.Context.init(null, gpa.allocator(), .{});
     errdefer app.audio_ctx.deinit();


### PR DESCRIPTION
This updates the examples to the latest mach/core API accounting for the removal of the *Core allocation. See https://github.com/hexops/mach/pull/681

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.