### PR TITLE
README: update to latest Zig version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ pub fn build(b: *std.Build) !void {
         .name = "myapp",
         .src = "src/main.zig",
         .target = target,
-        .deps = &[_]std.build.Pkg{},
-        .mode = mode,
+        .deps = &[_]std.build.ModuleDependency{},
+        .optimize = optimize,
     });
     try app.link(.{});
     app.install();


### PR DESCRIPTION
Hey! Thanks for working on mach - was trying out the examples and found issues with the quickstart on `0.11.0-dev.1824+a7a709aaa` not being able to build:

1) use `optimize` instead of `mode`
2) use `ModuleDependency` instead of `Pkg`


- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.